### PR TITLE
feature/improvements

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:$androidGradlePluginVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20"
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Oct 12 10:55:54 PKT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -465,7 +465,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pspdfkit.flutter.pspdfkitExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pspdfkit.flutter.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -491,7 +491,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Flutter",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.pspdfkit.flutter.pspdfkitExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pspdfkit.flutter.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/example/lib/pspdfkit_basic_example.dart
+++ b/example/lib/pspdfkit_basic_example.dart
@@ -18,20 +18,41 @@ class PspdfkitBasicExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        extendBodyBehindAppBar: PlatformUtils.isAndroid(),
-        // Do not resize the the document view on Android or
-        // it won't be rendered correctly when filling forms.
-        resizeToAvoidBottomInset: PlatformUtils.isIOS(),
-        appBar: AppBar(),
-        body: SafeArea(
-            top: false,
-            bottom: false,
-            child: Container(
-                padding: PlatformUtils.isAndroid()
-                    ? const EdgeInsets.only(top: kToolbarHeight)
-                    : null,
-                child: PspdfkitWidget(
-                  documentPath: documentPath,
-                ))));
+      extendBodyBehindAppBar: PlatformUtils.isAndroid(),
+      // Do not resize the the document view on Android or
+      // it won't be rendered correctly when filling forms.
+      resizeToAvoidBottomInset: PlatformUtils.isIOS(),
+      appBar: AppBar(),
+      body: SafeArea(
+        top: false,
+        bottom: false,
+        child: Container(
+          padding: PlatformUtils.isAndroid()
+              ? const EdgeInsets.only(top: kToolbarHeight)
+              : null,
+          child: PspdfkitWidget(
+            documentPath: documentPath,
+            onAnnotationsChanged: (controller) async {
+              print("test annotation changed");
+              print("test controller ${await controller.getZoomScale(0)}");
+            },
+            onPspdfkitWidgetCreated: (controller) async {
+
+              await controller.setAnnotationConfigurations({
+                AnnotationTool.inkPen: InkAnnotationConfiguration(
+                  thickness: 2,
+                  color: Colors.black,
+                )
+              });
+            },
+            configuration: PdfConfiguration(
+              askForAnnotationUsername: false,
+              allowAnnotationDeletion: false,
+              enableAnnotationEditing: true,
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Oct 12 10:53:55 PKT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/ios/Classes/FlutterPdfDocument.swift
+++ b/ios/Classes/FlutterPdfDocument.swift
@@ -11,12 +11,12 @@ import Foundation
 
 @objc(FlutterPdfDocument)
 public class FlutterPdfDocument: NSObject {
-    
+
     // MARK: - Properties
     var document: Document?
     var messenger: FlutterBinaryMessenger?
     var chanel: FlutterMethodChannel?
-    
+
   @objc public init(document: Document, messenger: FlutterBinaryMessenger) {
         super.init()
         self.document = document

--- a/ios/Classes/PspdfPlatformView.m
+++ b/ios/Classes/PspdfPlatformView.m
@@ -73,6 +73,11 @@
             
             [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(documentDidFinishRendering) name:PSPDFDocumentViewControllerDidConfigureSpreadViewNotification object:nil];
 
+            // Start listening to the annotation's change notification.
+            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationChangedNotification object:nil];
+            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationsAddedNotification object:nil];
+            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(annotationChangedNotification:) name:PSPDFAnnotationsRemovedNotification object:nil];
+
             if ((id)configurationDictionary != NSNull.null) {
                 NSString *key = @"leftBarButtonItems";
                 if (configurationDictionary[key]) {
@@ -135,6 +140,13 @@
         _flutterPdfDocument = [[FlutterPdfDocument alloc] initWithDocument:self.pdfViewController.document messenger: _binaryMessenger];
         [_channel invokeMethod:@"onDocumentLoaded" arguments:arguments];
     }
+}
+
+- (void)annotationChangedNotification:(NSNotification *)notification {
+    NSDictionary *arguments = @{
+        @"documentId": self.pdfViewController.document.UID,
+    };
+    [_channel invokeMethod:@"onAnnotationsChanged" arguments: arguments];
 }
 
 - (void) pdfViewController:(PSPDFViewController *)pdfController willBeginDisplayingPageView:(PSPDFPageView *)pageView forPageAtIndex:(NSInteger)pageIndex {

--- a/ios/Classes/PspdfPlatformView.m
+++ b/ios/Classes/PspdfPlatformView.m
@@ -15,7 +15,21 @@
 @import PSPDFKit;
 @import PSPDFKitUI;
 
-@interface PspdfPlatformView() <PSPDFViewControllerDelegate>
+// Custom subclass to control swipe-to-delete based on allowAnnotationDeletion
+@interface CustomAnnotationTableViewController : PSPDFAnnotationTableViewController
+@property (nonatomic, assign) BOOL allowAnnotationDeletion;
+@end
+
+@implementation CustomAnnotationTableViewController
+
+// Override to control swipe-to-delete
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    return self.allowAnnotationDeletion; // Control editing based on the property
+}
+
+@end
+
+@interface PspdfPlatformView() <PSPDFViewControllerDelegate, PSPDFAnnotationTableViewControllerDelegate>
 @property int64_t platformViewId;
 @property (nonatomic) FlutterMethodChannel *channel;
 @property (nonatomic) FlutterMethodChannel *broadcastChannel;
@@ -24,6 +38,7 @@
 @property (nonatomic) PSPDFNavigationController *navigationController;
 @property (nonatomic) FlutterPdfDocument *flutterPdfDocument;
 @property (nonatomic) NSObject<FlutterBinaryMessenger> *binaryMessenger;
+@property (nonatomic, assign) BOOL allowAnnotationDeletion;
 @end
 
 @implementation PspdfPlatformView
@@ -59,14 +74,43 @@
            
             NSDictionary *configurationDictionary = [PspdfkitFlutterConverter processConfigurationOptionsDictionaryForPrefix:args[@"configuration"]];
             PSPDFDocument *document = [PspdfkitFlutterHelper documentFromPath:documentPath];
-            
+
+            // Extract and assign allowAnnotationDeletion
+            BOOL allowAnnotationDeletion = YES;
+            if (configurationDictionary[@"allowAnnotationDeletion"] != nil) {
+                allowAnnotationDeletion = [configurationDictionary[@"allowAnnotationDeletion"] boolValue];
+            }
+            self.allowAnnotationDeletion = allowAnnotationDeletion;
+            NSLog(@"[PSPDFKit] allowAnnotationDeletion: %@", self.allowAnnotationDeletion ? @"YES" : @"NO");
+
+
+            BOOL askForAnnotationUsername = YES;
+            if (configurationDictionary[@"askForAnnotationUsername"] != nil) {
+                askForAnnotationUsername = [configurationDictionary[@"askForAnnotationUsername"] boolValue];
+            }
+
+            if (askForAnnotationUsername == NO) {
+                document.defaultAnnotationUsername = configurationDictionary[@"defaultAuthorName"];
+            }
+
             NSArray *measurementValueConfigurations = configurationDictionary[@"measurementValueConfigurations"];
           
             [PspdfkitFlutterHelper unlockWithPasswordIfNeeded:document dictionary:configurationDictionary];
 
             BOOL isImageDocument = [PspdfkitFlutterHelper isImageDocument:documentPath];
             PSPDFConfiguration *configuration = [PspdfkitFlutterConverter configuration:configurationDictionary isImageDocument:isImageDocument];
-            _pdfViewController = [[PSPDFViewController alloc] initWithDocument:document configuration:configuration];
+
+            // Update the configuration to set 'shouldAskForAnnotationUsername'
+            PSPDFConfiguration *updatedConfiguration = [configuration configurationUpdatedWithBuilder:^(PSPDFConfigurationBuilder *builder) {
+                builder.shouldAskForAnnotationUsername = askForAnnotationUsername;
+                NSLog(@"[PSPDFKit] shouldAskForAnnotationUsername: %@", builder.shouldAskForAnnotationUsername ? @"YES" : @"NO");
+                NSLog(@"[PSPDFKit] defaultAuthorName %@", configurationDictionary[@"defaultAuthorName"]);
+
+                // Override PSPDFAnnotationTableViewController with our custom subclass
+                [builder overrideClass:[PSPDFAnnotationTableViewController class] withClass:[CustomAnnotationTableViewController class]];
+            }];
+
+            _pdfViewController = [[PSPDFViewController alloc] initWithDocument:document configuration:updatedConfiguration];
             _pdfViewController.appearanceModeManager.appearanceMode = [PspdfkitFlutterConverter appearanceMode:configurationDictionary];
             _pdfViewController.pageIndex = [PspdfkitFlutterConverter pageIndex:configurationDictionary];
             _pdfViewController.delegate = self;
@@ -125,6 +169,39 @@
     }
 
     return self;
+}
+
+// Helper method to find the annotation controller
+- (PSPDFAnnotationTableViewController *)findAnnotationControllerIn:(UIViewController *)controller {
+    if ([controller isKindOfClass:[PSPDFAnnotationTableViewController class]]) {
+        return (PSPDFAnnotationTableViewController *)controller;
+    } else if ([controller isKindOfClass:[UINavigationController class]]) {
+        return [self findAnnotationControllerIn:((UINavigationController *)controller).topViewController];
+    } else if ([controller isKindOfClass:[PSPDFContainerViewController class]]) {
+        for (UIViewController *childController in ((PSPDFContainerViewController *)controller).viewControllers) {
+            PSPDFAnnotationTableViewController *foundController = [self findAnnotationControllerIn:childController];
+            if (foundController) {
+                return foundController;
+            }
+        }
+    }
+    return nil;
+}
+
+// Implement the delegate method
+- (BOOL)pdfViewController:(PSPDFViewController *)pdfController
+     shouldShowController:(UIViewController *)controller
+                  options:(NSDictionary<NSString *, id> *)options
+        animated:(BOOL)animated {
+    PSPDFAnnotationTableViewController *annotationController = [self findAnnotationControllerIn:controller];
+    if (annotationController) {
+        if ([annotationController isKindOfClass:[CustomAnnotationTableViewController class]]) {
+            CustomAnnotationTableViewController *customController = (CustomAnnotationTableViewController *)annotationController;
+            customController.allowAnnotationDeletion = self.allowAnnotationDeletion;
+            NSLog(@"[PSPDFKit] Setting allowAnnotationDeletion to %@", self.allowAnnotationDeletion ? @"YES" : @"NO");
+        }
+    }
+    return YES;
 }
 
 - (void)documentDidFinishRendering {

--- a/ios/Classes/PspdfPlatformView.m
+++ b/ios/Classes/PspdfPlatformView.m
@@ -157,6 +157,22 @@
     [_channel invokeMethod:@"onPageChanged" arguments: arguments];
 }
 
+// should suppress file conflict alerts https://pspdfkit.com/guides/ios/knowledge-base/suppressing-file-coordination-alerts/
+// ...but seems to be not working
+- (BOOL)resolutionManager:(PSPDFConflictResolutionManager *)manager shouldPerformAutomaticResolutionForForDocument:(PSPDFDocument *)document dataProvider:(id<PSPDFCoordinatedFileDataProviding>)dataProvider conflictType:(PSPDFFileConflictType)type 
+               resolution:(inout PSPDFFileConflictResolution *)resolution {
+    switch (type) {
+        case PSPDFFileConflictTypeDeletion:
+            // Unconditionally close the document — EVEN WHEN THERE ARE UNSAVED CHANGES!
+            *resolution = PSPDFFileConflictResolutionClose;
+            return YES;
+        case PSPDFFileConflictTypeModification:
+            // Unconditionally reload the document from disk — EVEN WHEN THERE ARE UNSAVED CHANGES!
+            *resolution = PSPDFFileConflictResolutionReload;
+            return YES;
+    }
+}
+
 - (void)dealloc {
     [self cleanup];
 }

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -44,13 +44,13 @@ PSPDFSettingKey const PSPDFSettingKeyHybridEnvironment = @"com.pspdfkit.hybrid-e
         if ([licenseKey isKindOfClass:[NSNull class]]|| licenseKey.length <= 0) {
             return;
         }
-        [PSPDFKitGlobal setLicenseKey:licenseKey options:@{PSPDFSettingKeyHybridEnvironment: @"Flutter"}];
+        [PSPDFKitGlobal setLicenseKey:licenseKey options:@{PSPDFSettingKeyHybridEnvironment: @"Flutter", PSPDFSettingKeyFileCoordinationEnabled: @false}];
     } else if ([@"setLicenseKeys" isEqualToString:call.method]) {
         NSString *iOSLicenseKey = call.arguments[@"iOSLicenseKey"];
         if ([iOSLicenseKey isKindOfClass:[NSNull class]]|| iOSLicenseKey.length <= 0) {
             return;
         }
-        [PSPDFKitGlobal setLicenseKey:iOSLicenseKey options:@{PSPDFSettingKeyHybridEnvironment: @"Flutter"}];
+        [PSPDFKitGlobal setLicenseKey:iOSLicenseKey options:@{PSPDFSettingKeyHybridEnvironment: @"Flutter", PSPDFSettingKeyFileCoordinationEnabled: @false}];
     }else if ([@"present" isEqualToString:call.method]) {
         
         NSString *documentPath = call.arguments[@"document"];

--- a/ios/Classes/PspdfkitPlugin.m
+++ b/ios/Classes/PspdfkitPlugin.m
@@ -140,6 +140,19 @@ PSPDFSettingKey const PSPDFSettingKeyHybridEnvironment = @"com.pspdfkit.hybrid-e
     }
 }
 
+- (void)setAnnotationConfigurations:(NSDictionary *)configurations {
+    if (!self.pdfViewController) {
+        NSLog(@"[PSPDFKit] pdfViewController is nil. Cannot apply annotation configurations.");
+        return;
+    }
+
+    // Convert configurations from Flutter to native PSPDFKit configurations
+    [AnnotationsPresetConfigurations setConfigurationsWithAnnotationPreset:configurations];
+
+    NSLog(@"[PSPDFKit] Applied annotation configurations.");
+}
+
+
 - (void) setupViewController:(NSDictionary *)configurationDictionary result:(FlutterResult)result  {
     
         self.pdfViewController.appearanceModeManager.appearanceMode = [PspdfkitFlutterConverter appearanceMode:configurationDictionary];

--- a/lib/src/pdf_configuration.dart
+++ b/lib/src/pdf_configuration.dart
@@ -174,6 +174,15 @@ class PdfConfiguration {
   /// Sets the minimum zoom scale. Defaults to null.
   final double? minimumZoomScale;
 
+  /// Sets whether to ask for the username when adding an annotation.
+  final bool askForAnnotationUsername;
+
+  /// Sets whether to show the author name in the annotation inspector.
+  final String defaultAuthorName;
+
+  /// Sets whether to allow the deletion of annotations from outline window.
+  final bool allowAnnotationDeletion;
+
   PdfConfiguration(
       {this.scrollDirection,
       this.pageTransition,
@@ -222,7 +231,10 @@ class PdfConfiguration {
       this.annotationToolsGrouping,
       this.defaultZoomScale,
       this.maximumZoomScale,
-      this.minimumZoomScale});
+      this.minimumZoomScale,
+        this.defaultAuthorName = 'unnamed',
+      this.askForAnnotationUsername = true,
+      this.allowAnnotationDeletion = true});
 
   /// Returns a [Map] representation of the [PdfConfiguration] object.
   /// This is used to pass the configuration to the platform side.
@@ -268,6 +280,9 @@ class PdfConfiguration {
       'enableMeasurementTools': enableMeasurementTools,
       'enableMeasurementToolSnapping': measurementSnappingEnabled,
       'enableMagnifier': enableMagnifier,
+      'askForAnnotationUsername': askForAnnotationUsername,
+      'defaultAuthorName': defaultAuthorName,
+      'allowAnnotationDeletion': allowAnnotationDeletion,
       'measurementValueConfigurations':
           measurementValueConfigurations?.map((e) => e.toMap()).toList(),
       'toolbarItemGrouping': convertAnnotationToolsGrouping(),

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -254,6 +254,8 @@ typedef PdfDocumentLoadFailedCallback = void Function(String error);
 
 typedef PageChangedCallback = void Function(int pageIndex);
 
+typedef AnnotationsChangedCallback = void Function(PspdfkitWidgetController controller);
+
 extension WebShowSignatureValidationStatusMode
     on ShowSignatureValidationStatusMode {
   String? get webName {

--- a/lib/src/widgets/pspdfkit_widget.dart
+++ b/lib/src/widgets/pspdfkit_widget.dart
@@ -9,13 +9,15 @@
 library pspdfkit_widget;
 
 import 'dart:async';
-import 'package:flutter/services.dart';
+
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:pspdfkit_flutter/pspdfkit.dart';
+
 import 'pspdfkit_widget_controller_native.dart';
 
 class PspdfkitWidget extends StatefulWidget {
@@ -25,6 +27,7 @@ class PspdfkitWidget extends StatefulWidget {
   final PdfDocumentLoadedCallback? onPdfDocumentLoaded;
   final PdfDocumentLoadFailedCallback? onPdfDocumentError;
   final PageChangedCallback? onPageChanged;
+  final AnnotationsChangedCallback? onAnnotationsChanged;
 
   const PspdfkitWidget({
     Key? key,
@@ -34,6 +37,7 @@ class PspdfkitWidget extends StatefulWidget {
     this.onPdfDocumentLoaded,
     this.onPdfDocumentError,
     this.onPageChanged,
+    this.onAnnotationsChanged,
   }) : super(key: key);
 
   @override
@@ -118,6 +122,7 @@ class _PspdfkitWidgetState extends State<PspdfkitWidget> {
       onPageChanged: widget.onPageChanged,
       onPdfDocumentLoadFailed: widget.onPdfDocumentError,
       onPdfDocumentLoaded: widget.onPdfDocumentLoaded,
+      onAnnotationsChanged: widget.onAnnotationsChanged,
     );
     widget.onPspdfkitWidgetCreated?.call(controller);
   }

--- a/lib/src/widgets/pspdfkit_widget_controller_native.dart
+++ b/lib/src/widgets/pspdfkit_widget_controller_native.dart
@@ -113,7 +113,7 @@ class PspdfkitWidgetControllerNative extends PspdfkitWidgetController {
     Map<AnnotationTool, AnnotationConfiguration> configurations,
   ) async {
     await _channel
-        .invokeMethod('setAnnotationConfigurations', <String, dynamic>{
+        .invokeMethod('setAnnotationPresetConfigurations', <String, dynamic>{
       'annotationConfigurations': configurations.map((key, value) {
         return MapEntry(key.name, value.toMap());
       }),

--- a/lib/src/widgets/pspdfkit_widget_controller_native.dart
+++ b/lib/src/widgets/pspdfkit_widget_controller_native.dart
@@ -8,6 +8,7 @@
 ///
 
 import 'package:flutter/services.dart';
+
 import '../../pspdfkit.dart';
 import '../document/pdf_document_native.dart';
 
@@ -20,6 +21,7 @@ class PspdfkitWidgetControllerNative extends PspdfkitWidgetController {
     PdfDocumentLoadedCallback? onPdfDocumentLoaded,
     PdfDocumentLoadFailedCallback? onPdfDocumentLoadFailed,
     PageChangedCallback? onPageChanged,
+    AnnotationsChangedCallback? onAnnotationsChanged,
   }) : _channel = MethodChannel('com.pspdfkit.widget.$id') {
     _channel.setMethodCallHandler((call) async {
       switch (call.method) {
@@ -34,6 +36,9 @@ class PspdfkitWidgetControllerNative extends PspdfkitWidgetController {
         case 'onPageChanged':
           var pageIndex = call.arguments['pageIndex'];
           onPageChanged?.call(pageIndex);
+          break;
+        case 'onAnnotationsChanged':
+          onAnnotationsChanged?.call(this);
           break;
       }
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pspdfkit_flutter
 description: A Flutter plugin providing a feature-rich PDF viewing and editing experience to your users with the powerful PSPDFKit PDF SDK.
-version: 3.12.0
+version: 3.12.1
 homepage: https://pspdfkit.com/
 repository: https://github.com/PSPDFKit/pspdfkit-flutter
 issue_tracker: https://support.pspdfkit.com/hc/en-us/requests/new


### PR DESCRIPTION
# Details

 This branch introduces many features as per requirements and fixes few warnings from old deprecated APIs. Below listed features are introduced corresponding to platforms.

### Feature (1)

Previously, when we were adding annotations PSPDFKit library over a pdf document, it prompt us to enter author name on every new document. A boolean field `askForAnnotationUsername` introduced to either we want this functionality or not. In addition to the same issue, a new field `defaultAuthorName` is introduced to add a default author name.

Code example:

```dart PspdfkitWidget(
  configuration: PdfConfiguration(
    askForAnnotationUsername: false // toggle
    defaultAuthorName: "John Doe" // won't be assigned if we ignore it.
  )
)
```

Test result flutter: Android [ ✅ ] & iOS [ ✅ ]

### Feature (2)

Previously, when `enableAnnotationEditing` was `false`, it was correctly preventing annotations for being editing but from a tabview where we navigate from an outline button had a list of annotations of all the pdf pages, there, on iOS we were still able to swipe-to-delete annotations but the annotations were not actually deleted but the behaviour were existed which was causing confusion. And on Android, tapping or editing an disabled annotation from the annotation list leading to app crash.

Now, a new boolean field `allowAnnotationDeletion` is introduced which work along with `enableAnnotationEditing` to fix the above issues.

on iOS: when above mentioned both fields are `false`, annotation editing is disabled and we cannot anymore interact with the annotation list since the editing was disabled in this PR.
on Android: when above mentioned both fields are `false`, annotation editing is disabled and the annotation list is removed from tabview.

Reason of removing the annotation list tab: When editing was false, interacting with annotations from the list was leading to an app crash on Android, saying `com.pspdfkit.exceptions.PSPDFKitException: Entering annotation editing mode for [] is not permitted, either by the license or configuration` and since we're not exposed to edit the UI code to manually disable the behaviour of the annotation list on android side and just doing `.disableAnnotationList()` which is the only callback they provide which I did leads to remove the complete tab from the tabview preventing crash.

Test result flutter: Android [ ✅ ] & iOS [ ✅ ]

### Feature (3)

Previously, when I tried to add annotation configuration using `.setAnnotationConfiguration` method from `PspdfkitWidgetController` it was throwing Missing Plugin Implementation for a method. It was the problem with, we were invoking a method with name `annotationConfiguration` but on platform specific side the code was accessing the method as `annotationPresentConfiguration`. Syncing the names make it work. Now, we're able to add default config for pdf document including default thickness, colour and more.

Test result flutter: Android [ ✅ ] & iOS [ ✅ ]

### Feature (4)

Previously, I figured out, `onAnnotationsChanged` callback was only working on iOS and wasn't implemented on Android. I added callbacks to Android side and now callbacks are send to `onAnnotationsChanged` even on Android.

Test result flutter: Android [ ✅ ] & iOS [ ✅ ]

Moreover, on Android, there were few warnings to missing `@Deprecated` decoration over some deprecated methods and properties. I added this and now we're no more receiving these warnings on Android.

# Acceptance Criteria

- [ ✅ ] Before merging retest all the examples to make sure that they work on both Android and iOS.
